### PR TITLE
Correctly commit and push built font on PR merge

### DIFF
--- a/.github/workflows/make-font.yml
+++ b/.github/workflows/make-font.yml
@@ -25,8 +25,11 @@ jobs:
         with:
           push: False
           message: "Update font-file"
+          branch: master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate current branch
+        run: git branch --show-current
       - name: Bump version
         if: github.event.pull_request.merged == true
         run: npm version patch
@@ -34,8 +37,8 @@ jobs:
         if: github.event.pull_request.merged == true
         uses: ad-m/github-push-action@master
         with:
-          tags: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: master
       - name: Trigger pyglui font update
         if: github.event.pull_request.merged == true
         uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
Squashed commit of the following:

commit e822ea16a16791ecb0ae093ba94f40ae6270cfd3
Author: Pablo Prietz <pablo@prietz.org>
Date:   Mon Jun 28 15:38:32 2021 +0200

    Explicitly commit to master instead of PR branch

commit 284d3c6dafe4606bfb5e7dc1d07cf495f6139b27
Author: Pablo Prietz <pablo@prietz.org>
Date:   Mon Jun 28 15:32:02 2021 +0200

    Use ad-m/github-push-action@master

commit 5e808d8e0f73dcf351e9a774a214840e48a0c5b4
Author: Pablo Prietz <pablo@prietz.org>
Date:   Mon Jun 28 15:22:09 2021 +0200

    Add env.GITHUB_TOKEN

commit ac89f608a2ff52e13c12ff67ddb031ed2498561d
Author: Pablo Prietz <pablo@prietz.org>
Date:   Mon Jun 28 15:16:16 2021 +0200

    Use EndBug/add-and-commit@v5 for pushing